### PR TITLE
Fix: GitHub Actions (Build APK)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Build APK
 
-on: [workflow_dispatch, push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   android:


### PR DESCRIPTION
Only run the Build APK workflow when pushing to main