### PR TITLE
Feat: fix bottom sheet sizing in Messages screen

### DIFF
--- a/lib/pages/messages.dart
+++ b/lib/pages/messages.dart
@@ -169,9 +169,7 @@ class _MessagesPageState extends State<MessagesPage> {
                                                                     return Center(
                                                                       child: Column(
                                                                         children: [
-                                                                          // ignore: sized_box_for_whitespace
-                                                                          Container(
-                                                                              height: MediaQuery.of(context).size.height - 100,
+                                                                          Expanded(
                                                                               child: InAppWebView(
                                                                                   initialUrlRequest: URLRequest(url: WebUri(e.url.toString())),
                                                                                   initialUserScripts: UnmodifiableListView([


### PR DESCRIPTION
Dynamically resize the height of the bottom sheet using Expanded() instead of determining a fixed height based on context height